### PR TITLE
add ellipse functionality to pairsplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,5 +43,5 @@ URL: https://github.com/kevinblighe/PCAtools
 biocViews: RNASeq, ATACSeq, GeneExpression, Transcription, SingleCell, PrincipalComponent
 VignetteBuilder:
   knitr
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8

--- a/R/pairsplot.R
+++ b/R/pairsplot.R
@@ -77,6 +77,24 @@
 #'   gridlines.
 #' @param borderWidth Width of the border on the x and y axes.
 #' @param borderColour Colour of the border on the x and y axes.
+#' @param ellipse Logical, indicating whether to draw a data ellipse around
+#'   the groups specified by 'colby'.
+#' @param ellipseType The type of ellipse. "t" assumes a multivariate 
+#'   t-distribution, "norm" assumes a multivariate normal distribution, 
+#'   "euclid" draws a circle with radius equal to level.
+#' @param ellipseLevel The level at which to draw an ellipse (default 0.95 
+#'   for 95% confidence region).
+#' @param ellipseSegments The number of segments to be used in drawing the 
+#'   ellipse (default 51).
+#' @param ellipseFill Logical, if 'ellipse == TRUE', this determines
+#'   whether to fill the ellipse region or not.
+#' @param ellipseFillKey Vector of name-value pairs relating to value passed to
+#'   'ellipseFill', e.g., c(A='forestgreen', B='gold'). If NULL, the fill
+#'   is controlled by whatever has already been used for 'colby' / 'colkey'.
+#' @param ellipseAlpha Alpha for purposes of controlling colour transparency of
+#'   the ellipse region. Used when 'ellipse == TRUE'.
+#' @param ellipseLineSize Line width of the ellipse line when 'ellipse == TRUE'.
+#' @param ellipseLineCol Colour of the ellipse line when 'ellipse == TRUE'.
 #' @param returnPlot Logical, indicating whether or not to return the plot
 #'   object.
 #'
@@ -173,6 +191,15 @@ pairsplot <- function(
     gridlines.minor = TRUE,
     borderWidth = 0.8,
     borderColour = 'black',
+    ellipse = FALSE,
+    ellipseType = 't',
+    ellipseLevel = 0.95,
+    ellipseSegments = 51,
+    ellipseFill = TRUE,
+    ellipseFillKey = NULL,
+    ellipseAlpha = 1/4,
+    ellipseLineSize = 0.25,
+    ellipseLineCol = NULL,
     returnPlot = TRUE)
 {
   # biplots is a list that will be populated with biplot()
@@ -247,6 +274,15 @@ pairsplot <- function(
                                     drawConnectors = drawConnectors,
                                     widthConnectors = widthConnectors,
                                     colConnectors = colConnectors,
+                                    ellipse = ellipse,
+                                    ellipseType = ellipseType,
+                                    ellipseLevel = ellipseLevel,
+                                    ellipseSegments = ellipseSegments,
+                                    ellipseFill = ellipseFill,
+                                    ellipseFillKey = ellipseFillKey,
+                                    ellipseAlpha = ellipseAlpha,
+                                    ellipseLineSize = ellipseLineSize,
+                                    ellipseLineCol = ellipseLineCol,
                                     hline = hline,
                                     hlineType = hlineType,
                                     hlineCol = hlineCol,

--- a/man/pairsplot.Rd
+++ b/man/pairsplot.Rd
@@ -55,6 +55,15 @@ pairsplot(
   gridlines.minor = TRUE,
   borderWidth = 0.8,
   borderColour = "black",
+  ellipse = FALSE,
+  ellipseType = "t",
+  ellipseLevel = 0.95,
+  ellipseSegments = 51,
+  ellipseFill = TRUE,
+  ellipseFillKey = NULL,
+  ellipseAlpha = 1/4,
+  ellipseLineSize = 0.25,
+  ellipseLineCol = NULL,
   returnPlot = TRUE
 )
 }
@@ -185,6 +194,33 @@ gridlines.}
 \item{borderWidth}{Width of the border on the x and y axes.}
 
 \item{borderColour}{Colour of the border on the x and y axes.}
+
+\item{ellipse}{Logical, indicating whether to draw a data ellipse around
+the groups specified by 'colby'.}
+
+\item{ellipseType}{The type of ellipse. "t" assumes a multivariate 
+t-distribution, "norm" assumes a multivariate normal distribution, 
+"euclid" draws a circle with radius equal to level.}
+
+\item{ellipseLevel}{The level at which to draw an ellipse (default 0.95 
+for 95% confidence region).}
+
+\item{ellipseSegments}{The number of segments to be used in drawing the 
+ellipse (default 51).}
+
+\item{ellipseFill}{Logical, if 'ellipse == TRUE', this determines
+whether to fill the ellipse region or not.}
+
+\item{ellipseFillKey}{Vector of name-value pairs relating to value passed to
+'ellipseFill', e.g., c(A='forestgreen', B='gold'). If NULL, the fill
+is controlled by whatever has already been used for 'colby' / 'colkey'.}
+
+\item{ellipseAlpha}{Alpha for purposes of controlling colour transparency of
+the ellipse region. Used when 'ellipse == TRUE'.}
+
+\item{ellipseLineSize}{Line width of the ellipse line when 'ellipse == TRUE'.}
+
+\item{ellipseLineCol}{Colour of the ellipse line when 'ellipse == TRUE'.}
 
 \item{returnPlot}{Logical, indicating whether or not to return the plot
 object.}


### PR DESCRIPTION
This pull request adds new functionality to the `pairsplot` function, allowing users to draw data ellipses around groups in their plots. It introduces several new parameters for customizing the appearance and behavior of these ellipses, and updates documentation to reflect these changes.

### New ellipse feature for `pairsplot`:

* Added support for drawing data ellipses around groups specified by `colby`, with options for ellipse type, confidence level, number of segments, fill, color, transparency, and line styling in the `pairsplot` function (`R/pairsplot.R`). [[1]](diffhunk://#diff-a024ff1b1c9059ab0be65b01b1640ed4f65a6de72a4d6301ba478367146e8696R80-R97) [[2]](diffhunk://#diff-a024ff1b1c9059ab0be65b01b1640ed4f65a6de72a4d6301ba478367146e8696R194-R202)
* Passed new ellipse-related parameters to the underlying plotting logic within `pairsplot` to enable customization and rendering of ellipses (`R/pairsplot.R`).

### Documentation updates:

* Updated the function documentation in `man/pairsplot.Rd` to describe all new ellipse-related parameters and their usage.
* Added the new ellipse parameters to the usage example in the documentation (`man/pairsplot.Rd`).

### Miscellaneous:

* Updated the `RoxygenNote` version in the `DESCRIPTION` file to reflect the documentation changes.